### PR TITLE
Replaced requests module with https in node_helper.js

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -1,26 +1,31 @@
-
-var request = require('request');
+var https = require("https");
 var NodeHelper = require("node_helper");
 
 module.exports = NodeHelper.create({
+  start: function () {
+    console.log("Starting node helper: " + this.name);
+  },
 
-	start: function() {
-		console.log("Starting node helper: " + this.name);
+  socketNotificationReceived: function (notification, payload) {
+    var self = this;
+    console.log("Notification: " + notification + " Payload: " + payload);
 
-	},
-
-	socketNotificationReceived: function(notification, payload) {
-		var self = this;
-		console.log("Notification: " + notification + " Payload: " + payload);
-
-		if(notification === "GET_SOLAR") {
-			var enlightenUrl = payload.config.url + payload.config.systemId + "/summary?&key=" + payload.config.apiKey + "&user_id=" + payload.config.userId;
-			request(enlightenUrl, function (error, response, body) {
-				if (!error && response.statusCode == 200) {
-					var jsonData = JSON.parse(body);
-				        self.sendSocketNotification("SOLAR_DATA", jsonData);
-				}
-			});
-		}
-	},
+    if (notification === "GET_SOLAR") {
+      var enlightenUrl =
+        payload.config.url +
+        payload.config.systemId +
+        "/summary?&key=" +
+        payload.config.apiKey +
+        "&user_id=" +
+        payload.config.userId;
+      https.get(enlightenUrl, function (response) {
+        if (response.statusCode == 200) {
+          response.on("data", function (body) {
+            var jsonData = JSON.parse(body);
+            self.sendSocketNotification("SOLAR_DATA", jsonData);
+          });
+        }
+      });
+    }
+  },
 });


### PR DESCRIPTION
Updated node_helper.js to replace npm 'requests' module (which has been sunsetted and no longer works with the latest version of  magic mirror) with 'https' module.

fixes #8
fixes #7